### PR TITLE
Stackless issue #161: Add Stackless support to patchcheck.py

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -679,25 +679,6 @@ PyEval_EvalCode(PyCodeObject *co, PyObject *globals, PyObject *locals)
 
 /* Interpreter main loop */
 
-#ifdef STACKLESS
-PyObject *
-PyEval_EvalFrame(PyFrameObject *f)
-{
-    return PyEval_EvalFrameEx_slp(f, 0, NULL);
-}
-
-PyObject *
-PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
-{
-    return PyEval_EvalFrameEx_slp(f, throwflag, NULL);
-}
-
-PyObject *
-PyEval_EvalFrameEx_slp(PyFrameObject *f, int throwflag, PyObject *retval)
-{
-    PyThreadState *tstate = PyThreadState_GET();
-#else
-
 PyObject *
 PyEval_EvalFrame(PyFrameObject *f) {
     /* This is for backward compatibility with extension modules that
@@ -709,6 +690,18 @@ PyEval_EvalFrame(PyFrameObject *f) {
 PyObject *
 PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
 {
+#ifdef STACKLESS
+    /*
+     * This method is not used by Stackless Python. It is provided for compatibility
+     * with extension modules and Cython.
+     */
+    return PyEval_EvalFrameEx_slp(f, throwflag, NULL);
+}
+
+PyObject *
+PyEval_EvalFrameEx_slp(PyFrameObject *f, int throwflag, PyObject *retval)
+{
+    PyThreadState *tstate = PyThreadState_GET();
 #endif  /* not STACKLESS */
 #ifdef DYNAMIC_EXECUTION_PROFILE
     #undef USE_COMPUTED_GOTOS
@@ -1334,7 +1327,7 @@ slp_eval_frame_value(PyFrameObject *f, int throwflag, PyObject *retval)
             }
         }
         else {
-            /* don't push it, frame ignores value */
+            /* don't push retval, frame ignores the value */
             assert (f->f_execute == slp_eval_frame_noval);
             Py_XDECREF(retval);
         }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -695,7 +695,56 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
      * This method is not used by Stackless Python. It is provided for compatibility
      * with extension modules and Cython.
      */
-    return PyEval_EvalFrameEx_slp(f, throwflag, NULL);
+    PyThreadState *tstate = PyThreadState_GET();
+    PyObject * retval = NULL;
+
+    if (f == NULL)
+        return NULL;
+    /* make sure that the Stackless system has been initialized. */
+    assert(tstate->st.main && tstate->st.current);
+    /* sanity check. */
+    assert(SLP_CURRENT_FRAME_IS_VALID(tstate));
+    if (!throwflag) {
+        /* If throwflag is true, retval must be NULL. Otherwise it must be non-NULL.
+         */
+        Py_INCREF(Py_None);
+        retval = Py_None;
+    }
+    if (PyFrame_Check(f) && f->f_execute == NULL) {
+        /* A new frame returned from PyFrame_New() has f->f_execute == NULL.
+         */
+        f->f_execute = PyEval_EvalFrameEx_slp;
+    } else {
+        /* The layout of PyFrameObject differs between Stackless and C-Python.
+         * Stackless f->f_execute is C-Python f->f_code. Stackless f->f_code is at
+         * the end, just before f_localsplus.
+         *
+         * In order to detect a C-Python frame, we must compare f->f_execute
+         * with every valid frame function. Hard to implement completely.
+         * Therefore I'll check only for relevant functions.
+         * Amend the list as needed.
+         *
+         * If needed, we could try to fix an C-Python frame on the fly.
+         *
+         * (It is not possible to detect an C-Python frame by its size, because
+         * we need the code object to compute the expected size and the location
+         * of code objects varies between Stackless and C-Python frames).
+         */
+        if (!PyCFrame_Check(f) &&
+                f->f_execute != PyEval_EvalFrameEx_slp &&
+                f->f_execute != slp_eval_frame_value &&
+                f->f_execute != slp_eval_frame_noval &&
+                f->f_execute != slp_eval_frame_iter &&
+                f->f_execute != slp_eval_frame_setup_with &&
+                f->f_execute != slp_eval_frame_with_cleanup)  {
+            PyErr_BadInternalCall();
+            return NULL;
+        }
+    }
+    retval = slp_frame_dispatch(f, f->f_back, throwflag, retval);
+    assert(!STACKLESS_UNWINDING(retval));
+    assert(SLP_CURRENT_FRAME_IS_VALID(tstate));
+    return retval;
 }
 
 PyObject *

--- a/Stackless/changelog.txt
+++ b/Stackless/changelog.txt
@@ -10,6 +10,10 @@ What's New in Stackless 2.7.XX?
 
 *Release date: XXXX-XX-XX*
 
+- https://github.com/stackless-dev/stackless/issues/166
+  Fix C-API functions PyEval_EvalFrameEx() and PyEval_EvalFrame().
+  They are now compatible with C-Python.
+
 
 What's New in Stackless 2.7.15?
 ===============================

--- a/Stackless/module/stacklessmodule.c
+++ b/Stackless/module/stacklessmodule.c
@@ -1130,6 +1130,74 @@ static int init_test_nostacklesscalltype(void)
     return 0;
 }
 
+
+PyDoc_STRVAR(test_PyEval_EvalFrameEx__doc__,
+"test_PyEval_EvalFrameEx(code, globals, args=()) -- a builtin testing function.\n\
+This function tests the C-API function PyEval_EvalFrameEx(), which is not used\n\
+by Stackless Python.\n\
+The function creates a frame from code, globals and args and executes the frame.");
+
+static PyObject* test_PyEval_EvalFrameEx(PyObject *self, PyObject *args, PyObject *kwds) {
+    static char *kwlist[] = {"code", "globals", "args", "alloca", NULL};
+    PyThreadState *tstate = PyThreadState_GET();
+    PyCodeObject *co;
+    PyObject *globals, *co_args = NULL;
+    Py_ssize_t alloca_size = 0;
+    PyFrameObject *f;
+    PyObject *result = NULL;
+    void *p;
+    Py_ssize_t na;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!O!|O!n:test_PyEval_EvalFrameEx", kwlist,
+            &PyCode_Type, &co, &PyDict_Type, &globals, &PyTuple_Type, &co_args, &alloca_size))
+        return NULL;
+    p = alloca(alloca_size);
+    assert(globals != NULL);
+    assert(tstate != NULL);
+    na = PyTuple_Size(co->co_freevars);
+    if (na == -1)
+        return NULL;
+    if (na > 0) {
+        PyErr_Format(PyExc_ValueError, "code requires cell variables");
+        return NULL;
+    }
+    f = PyFrame_New(tstate, co, globals, NULL);
+    if (f == NULL) {
+        return NULL;
+    }
+    if (co_args) {
+        PyObject **fastlocals;
+        Py_ssize_t i;
+        na = PyTuple_Size(co_args);
+        if (na == -1)
+            goto exit;
+        if (na > co->co_argcount) {
+            PyErr_Format(PyExc_ValueError, "too many items in tuple 'args'");
+            goto exit;
+        }
+        fastlocals = f->f_localsplus;
+        for (i = 0; i < na; i++) {
+            PyObject *arg = PyTuple_GetItem(co_args, i);
+            if (arg == NULL) {
+                goto exit;
+            }
+            Py_INCREF(arg);
+            fastlocals[i] = arg;
+        }
+        if (alloca_size > 0 && na > 0) {
+            Py_SETREF(fastlocals[0], PyLong_FromVoidPtr(p));
+        }
+    }
+    result = PyEval_EvalFrameEx(f,0);
+    /* result = Py_None; Py_INCREF(Py_None); */
+exit:
+    ++tstate->recursion_depth;
+    Py_DECREF(f);
+    --tstate->recursion_depth;
+    return result;
+}
+
+
 /******************************************************
 
   The Stackless External Interface
@@ -1601,6 +1669,8 @@ static PyMethodDef stackless_methods[] = {
     test_outside__doc__},
     {"test_cstate",                 (PCF)test_cstate,           METH_O,
     test_cstate__doc__},
+    {"test_PyEval_EvalFrameEx",     (PCF)test_PyEval_EvalFrameEx, METH_VARARGS | METH_KEYWORDS,
+    test_PyEval_EvalFrameEx__doc__},
     {"set_channel_callback",        (PCF)set_channel_callback,  METH_O,
      set_channel_callback__doc__},
     {"get_channel_callback",        (PCF)get_channel_callback,  METH_NOARGS,

--- a/Stackless/unittests/test_capi.py
+++ b/Stackless/unittests/test_capi.py
@@ -1,0 +1,100 @@
+#
+# -*- coding: utf-8 -*-
+#
+#  Copyright 2018 science + computing ag
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Test the (Stackless)-Python C-API
+
+Tests not relevant for pure Python code.
+"""
+
+from __future__ import print_function, absolute_import, division
+
+import inspect
+import stackless
+import sys
+import unittest
+
+from support import test_main  # @UnusedImport
+from support import StacklessTestCase
+
+
+class Test_PyEval_EvalFrameEx(StacklessTestCase):
+    @staticmethod
+    def function(arg):
+        return arg
+
+    def call_PyEval_EvalFrameEx(self, *args, **kw):
+        f = self.function
+        if inspect.ismethod(f):
+            f = f.__func__
+        return stackless.test_PyEval_EvalFrameEx(f.__code__, f.__globals__, args, **kw)
+
+    def test_free_vars(self):
+        # stackless.test_PyEval_EvalFrameEx can't handle code, that contains free variables.
+        x = None
+
+        def f():
+            return x
+        self.assertTupleEqual(f.__code__.co_freevars, ('x',))
+        self.assertRaises(ValueError, stackless.test_PyEval_EvalFrameEx, f.__code__, f.__globals__)
+
+    def test_0_args(self):
+        self.assertRaises(UnboundLocalError, self.call_PyEval_EvalFrameEx)
+
+    def test_1_args(self):
+        self.assertEqual(self.call_PyEval_EvalFrameEx(47110815), 47110815)
+
+    def test_2_args(self):
+        self.assertRaises(ValueError, self.call_PyEval_EvalFrameEx, 4711, None)
+
+    def test_cstack_spilling(self):
+        # Force stack spilling. 16384 is the value of CSTACK_WATERMARK from slp_platformselect.h
+        self.call_PyEval_EvalFrameEx(None, alloca=16384 * 8)
+
+    def test_stack_unwinding(self):
+        # Calling the __init__ method of a new-style class involves stack unwinding
+        class C(object):
+            def __init__(self):
+                self.initialized = True
+
+        def f(C):
+            return C()
+
+        c = stackless.test_PyEval_EvalFrameEx(f.__code__, f.__globals__, (C,))
+        self.assertIsInstance(c, C)
+        self.assertTrue(c.initialized)
+
+    def test_tasklet_switch(self):
+        # test a tasklet switch out of the running frame
+        self.other_done = False
+
+        def other_tasklet():
+            self.other_done = True
+
+        def f():
+            stackless.run()
+            return 666
+
+        stackless.tasklet(other_tasklet)()
+        result = stackless.test_PyEval_EvalFrameEx(f.__code__, f.__globals__)
+        self.assertTrue(self.other_done)
+        self.assertEqual(result, 666)
+
+
+if __name__ == "__main__":
+    if not sys.argv[1:]:
+        sys.argv.append('-v')
+    unittest.main()

--- a/Tools/scripts/patchcheck.py
+++ b/Tools/scripts/patchcheck.py
@@ -9,6 +9,10 @@ import sysconfig
 import reindent
 import untabify
 
+try:
+    import stackless
+except ImportError:
+    stackless = None
 
 # Excluded directories which are copies of external libraries:
 # don't check their coding style
@@ -41,6 +45,12 @@ def status(message, modal=False, info=None):
             return result
         return call_fxn
     return decorated_fxn
+
+
+def is_stackless():
+    """Check if this is a Stackless Python source"""
+    return (stackless is not None and
+            os.path.exists(os.path.join(SRCDIR, 'Stackless')))
 
 
 def mq_patches_applied():
@@ -90,6 +100,8 @@ def get_base_branch():
         base_branch = "master"
     else:
         base_branch = "{0.major}.{0.minor}".format(version)
+    if is_stackless():
+        base_branch += "-slp"
     this_branch = get_git_branch()
     if this_branch is None or this_branch == base_branch:
         # Not on a git PR branch, so there's no base branch


### PR DESCRIPTION
Now Tools/scripts/patchcheck.py uses Stackless specific git base branches for Stackless source trees (i.e. "master-slp" instead of "master")
