### PR TITLE
Replace goobledigoobs trick with consistent and future-proof assembly.

### DIFF
--- a/Stackless/core/slp_transfer.c
+++ b/Stackless/core/slp_transfer.c
@@ -81,7 +81,6 @@ extern int slp_switch(void);
 #endif
 
 /* a write only variable used to prevent overly optimisation */
-intptr_t *global_goobledigoobs;
 static int
 climb_stack_and_transfer(PyCStackObject **cstprev, PyCStackObject *cst,
                          PyTaskletObject *prev)
@@ -96,15 +95,9 @@ climb_stack_and_transfer(PyCStackObject **cstprev, PyCStackObject *cst,
     intptr_t probe;
     register ptrdiff_t needed = &probe - ts->st.cstack_base;
     /* in rare cases, the need might have vanished due to the recursion */
-    register intptr_t *goobledigoobs;
     if (needed > 0) {
-        goobledigoobs = alloca(needed * sizeof(intptr_t));
-        if (goobledigoobs == NULL)
-            return -1;
-        /* hinder the compiler to optimise away 
-           goobledigoobs and the alloca call. 
-           This happens with gcc 4.7.x and -O2 */
-        global_goobledigoobs = goobledigoobs;
+        void* stack_ptr_tmp = alloca(needed * sizeof(intptr_t));
+        __asm__ volatile("" : : "g"(stack_ptr_tmp) : "memory");
     }
     return slp_transfer(cstprev, cst, prev);
 }

--- a/Stackless/core/stacklesseval.c
+++ b/Stackless/core/stacklesseval.c
@@ -281,11 +281,9 @@ climb_stack_and_eval_frame(PyFrameObject *f)
     intptr_t probe;
     ptrdiff_t needed = &probe - ts->st.cstack_base;
     /* in rare cases, the need might have vanished due to the recursion */
-    intptr_t *goobledigoobs;
     if (needed > 0) {
-        goobledigoobs = alloca(needed * sizeof(intptr_t));
-        if (goobledigoobs == NULL)
-            return NULL;
+        void* stack_ptr_tmp = alloca(needed * sizeof(intptr_t));
+        __asm__ volatile("" : : "g"(stack_ptr_tmp) : "memory");
     }
     return slp_eval_frame(f);
 }


### PR DESCRIPTION
the goobledigoobs trick has been and will always be an optimization target for compilers. In fact it no longer works for gcc 5.4. The only way to consistently have the alloca not optimized out is to issue assembly that reads from the pointer and instructs that a read/write may occur anywhere in memory. 

A little more work needs to be done to make this cross-platform -- perhaps a macro for the various platforms that clobbers a pointer. Facebook folly has such a wrapper here:
https://github.com/facebook/folly/blob/master/folly/Benchmark.h