### PR TITLE
Stackless issue #188: enable soft switching for sub-iterators, (async) generators and coroutines

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1110,10 +1110,13 @@ _PyEval_EvalFrameDefault(PyFrameObject *f, int throwflag)
                     && PyErr_ExceptionMatches(PyExc_StopIteration))
                     call_exc_trace(tstate->c_tracefunc, tstate->c_traceobj, tstate, f);
                 err = _PyGen_FetchStopIterationValue(&retval);
-                if (err < 0)
-                    goto error;
-                Py_DECREF(receiver);
-                SET_TOP(retval);
+                if (err < 0) {
+                    retval = NULL;
+                }
+                else {
+                    Py_DECREF(receiver);
+                    SET_TOP(retval);
+                }
             }
             else {
                 /* receiver remains on stack, retval is value to be yielded */

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -7,7 +7,7 @@
    */
 
 /* enable more aggressive intra-module optimizations, where available */
-#undef PY_LOCAL_AGGRESSIVE
+#define PY_LOCAL_AGGRESSIVE
 
 #include "Python.h"
 #include "internal/pystate.h"

--- a/Stackless/changelog.txt
+++ b/Stackless/changelog.txt
@@ -9,6 +9,17 @@ What's New in Stackless 3.X.X?
 
 *Release date: 20XX-XX-XX*
 
+- https://github.com/stackless-dev/stackless/issues/188
+  Enable stackless calls of sub-iterators and coroutines (technically: the
+  YIELD_FROM opcode) and of the following methods, if soft-switching is
+  enabled:
+    - generator.send() (generator.__next__() was already stackless);
+    - coroutine.send();
+    - coroutine_wrapper.__next__() and coroutine_wrapper.send();
+    - async_generator_asend.__next__() and async_generator_asend.send().
+  With this change it is possible to soft switch into/from the compound
+  statements "async for" and "async with".
+
 - https://github.com/stackless-dev/stackless/issues/190
   Silently ignore attempts to close a running generator, coroutine or
   asynchronous generator. This avoids spurious error messages, if such an

--- a/Stackless/core/stackless_impl.h
+++ b/Stackless/core/stackless_impl.h
@@ -378,6 +378,7 @@ PyObject * slp_eval_frame_noval(struct _frame *f,  int throwflag, PyObject *retv
 PyObject * slp_eval_frame_iter(struct _frame *f,  int throwflag, PyObject *retval);
 PyObject * slp_eval_frame_setup_with(struct _frame *f,  int throwflag, PyObject *retval);
 PyObject * slp_eval_frame_with_cleanup(struct _frame *f,  int throwflag, PyObject *retval);
+PyObject * slp_eval_frame_yield_from(struct _frame *f,  int throwflag, PyObject *retval);
 /* other eval_frame functions from module/scheduling.c */
 PyObject * slp_restore_tracing(PyFrameObject *f, int exc, PyObject *retval);
 /* other eval_frame functions from Objects/typeobject.c */

--- a/Stackless/core/stackless_methods.h
+++ b/Stackless/core/stackless_methods.h
@@ -14,8 +14,8 @@ typedef struct {
 #define MFLAG_OFS_IND(meth) MFLAG_OFS(meth) + MFLAG_IND
 
 static _stackless_method _stackless_methtable[] = {
-    /* from methodobject.c */
-    {&PyCFunction_Type,            MFLAG_OFS(tp_call)},
+    /* from classobject.c */
+    {&PyMethod_Type,            MFLAG_OFS(tp_call)},
     /* from descrobject.c */
     {&PyMethodDescr_Type,        MFLAG_OFS(tp_call)},
     {&PyClassMethodDescr_Type,    MFLAG_OFS(tp_call)},
@@ -24,10 +24,12 @@ static _stackless_method _stackless_methtable[] = {
     {&PyFunction_Type,            MFLAG_OFS(tp_call)},
     /* from genobject.c */
     {&PyGen_Type,                MFLAG_OFS(tp_iternext)},
+    {&_PyCoroWrapper_Type,        MFLAG_OFS(tp_iternext)},
+    {&_PyAsyncGenASend_Type,    MFLAG_OFS(tp_iternext)},
+    /* from methodobject.c */
+    {&PyCFunction_Type,            MFLAG_OFS(tp_call)},
     /* from typeobject.c */
     {&PyType_Type,                MFLAG_OFS(tp_call)},
-    /* from classobject.c */
-    {&PyMethod_Type,            MFLAG_OFS(tp_call)},
     /* from channelobject.c */
     {&PyChannel_Type,            MFLAG_OFS(tp_iternext)},
     {0, 0} /* sentinel */

--- a/Stackless/pickling/prickelpit.c
+++ b/Stackless/pickling/prickelpit.c
@@ -839,6 +839,7 @@ SLP_DEF_INVALID_EXEC(eval_frame_noval)
 SLP_DEF_INVALID_EXEC(eval_frame_iter)
 SLP_DEF_INVALID_EXEC(eval_frame_setup_with)
 SLP_DEF_INVALID_EXEC(eval_frame_with_cleanup)
+SLP_DEF_INVALID_EXEC(eval_frame_yield_from)
 SLP_DEF_INVALID_EXEC(slp_channel_seq_callback)
 SLP_DEF_INVALID_EXEC(slp_restore_tracing)
 SLP_DEF_INVALID_EXEC(slp_tp_init_callback)
@@ -1202,6 +1203,8 @@ static int init_frametype(PyObject * mod)
                              slp_eval_frame_setup_with, SLP_REF_INVALID_EXEC(eval_frame_setup_with))
         || slp_register_execute(&PyFrame_Type, "eval_frame_with_cleanup",
                              slp_eval_frame_with_cleanup, SLP_REF_INVALID_EXEC(eval_frame_with_cleanup))
+        || slp_register_execute(&PyFrame_Type, "eval_frame_yield_from",
+                             slp_eval_frame_yield_from, SLP_REF_INVALID_EXEC(eval_frame_yield_from))
         || slp_register_execute(&PyCFrame_Type, "channel_seq_callback",
                              slp_channel_seq_callback, SLP_REF_INVALID_EXEC(slp_channel_seq_callback))
         || slp_register_execute(&PyCFrame_Type, "slp_restore_tracing",


### PR DESCRIPTION
Enable soft switching for iterators/coroutines called by "yield from".
Work in progress, not functional, DO NOT MERGE!

