### PR TITLE
Stackless issue #190: Do not close running (async) generators or coroutines

### DIFF
--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -82,6 +82,15 @@ _PyGen_Finalize(PyObject *self)
     {
         _PyErr_WarnUnawaitedCoroutine((PyObject *)gen);
     }
+#ifdef STACKLESS
+    else if (gen->gi_running) {
+        /*
+         * Do not close a running generator.
+         * See Stackless issue 190.
+         */
+        res = NULL;
+    }
+#endif
     else {
         res = gen_close(gen, NULL);
     }

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -82,15 +82,6 @@ _PyGen_Finalize(PyObject *self)
     {
         _PyErr_WarnUnawaitedCoroutine((PyObject *)gen);
     }
-#ifdef STACKLESS
-    else if (gen->gi_running) {
-        /*
-         * Do not close a running generator.
-         * See Stackless issue 190.
-         */
-        res = NULL;
-    }
-#endif
     else {
         res = gen_close(gen, NULL);
     }
@@ -182,6 +173,15 @@ gen_send_ex(PyGenObject *gen, PyObject *arg, int exc, int closing)
     PyFrameObject *f = gen->gi_frame;
     PyObject *result;
 
+#ifdef STACKLESS
+    if (gen->gi_running && exc && closing) {
+        /*
+         * Do not close a running generator.
+         * See Stackless issue 190.
+         */
+        return NULL;
+    }
+#endif
     if (gen->gi_running) {
         const char *msg = "generator already executing";
         if (PyCoro_CheckExact(gen)) {

--- a/Stackless/changelog.txt
+++ b/Stackless/changelog.txt
@@ -9,6 +9,11 @@ What's New in Stackless 3.X.X?
 
 *Release date: 20XX-XX-XX*
 
+- https://github.com/stackless-dev/stackless/issues/190
+  Do not finalize running generators, coroutines or asynchronous generators
+  (without a custom finaliser), if they are deallocated as part of a paused,
+  restorable tasklet.
+
 - https://github.com/stackless-dev/stackless/issues/193
   Fix the macros PyTasklet_CheckExact(op) and PyChannel_CheckExact(op).
   Previously they contained a reference to a non existing variable.

--- a/Stackless/changelog.txt
+++ b/Stackless/changelog.txt
@@ -10,9 +10,9 @@ What's New in Stackless 3.X.X?
 *Release date: 20XX-XX-XX*
 
 - https://github.com/stackless-dev/stackless/issues/190
-  Do not finalize running generators, coroutines or asynchronous generators
-  (without a custom finaliser), if they are deallocated as part of a paused,
-  restorable tasklet.
+  Silently ignore attempts to close a running generator, coroutine or
+  asynchronous generator. This avoids spurious error messages, if such an
+  object is deallocated as part of a paused, restorable tasklet.
 
 - https://github.com/stackless-dev/stackless/issues/193
   Fix the macros PyTasklet_CheckExact(op) and PyChannel_CheckExact(op).

--- a/Stackless/unittests/test_generator.py
+++ b/Stackless/unittests/test_generator.py
@@ -37,9 +37,28 @@ class TestGarbageCollection(StacklessTestCase):
         if len(leakage):
             self.failUnless(len(leakage) == 0, "Leaked %s" % repr(leakage))
 
+    def run_GC_test(self, task, arg):
+        tasklet = stackless.tasklet(task)(arg)
+        tasklet.run()
+        if False:  # To test the generator / coroutine / async gen
+            tasklet.run()
+            self.assertFalse(tasklet.alive)
+            return
+        self.assertTrue(tasklet.paused)
+        tasklet.tempval = None
+        with captured_stderr() as stringio:
+            # must not throw or output
+            if tasklet.restorable:
+                tasklet.bind(None)
+            # make sure, that t=None kills the last reference
+            self.assertEqual(sys.getrefcount(tasklet), 2)
+            tasklet = None
+        self.assertEqual(stringio.getvalue(), "")
+
     def testGCRunningGenerator(self):
         def gen():
             try:
+                # print("gen nesting level: ", stackless.current.nesting_level)
                 stackless.schedule_remove()
                 yield 1
             except:  # @IgnorePep8
@@ -47,20 +66,44 @@ class TestGarbageCollection(StacklessTestCase):
                 raise
 
         def task(generator):
-            [i for i in generator]
+            l = [i for i in generator]
+            self.assertListEqual(l, [1])
 
-        t = stackless.tasklet(task)(gen())
-        stackless.run()
-        self.assertTrue(t.paused)
-        t.tempval = None
-        with captured_stderr() as stringio:
-            # must not throw or output
-            if t.restorable:
-                t.bind(None)
-            # make sure, that t=None kills the last reference
-            self.assertEqual(sys.getrefcount(t), 2)
-            t = None
-        self.assertEqual(stringio.getvalue(), "")
+        self.run_GC_test(task,gen())
+
+    def testGCRunningCoroutine(self):
+        async def coro():
+            try:
+                # print("coro nesting level: ", stackless.current.nesting_level)
+                stackless.schedule_remove()
+            except:  # @IgnorePep8
+                # print("exception in coro:", sys.exc_info())
+                raise
+
+        def task(c):
+            self.assertRaises(StopIteration, c.send, None)
+
+        self.run_GC_test(task, coro())
+
+    def testGCRunningAsyncGen(self):
+        async def asyncgen():
+            try:
+                # print("asyncgen nesting level: ", stackless.current.nesting_level)
+                stackless.schedule_remove()
+            except:  # @IgnorePep8
+                # print("exception in asyncgen:", sys.exc_info())
+                raise
+            yield 100
+
+        def task(ag):
+            c = ag.__anext__()
+            with self.assertRaises(StopIteration) as cm:
+                c.send(None)
+            self.assertEqual(cm.exception.value, 100)
+            c = ag.__anext__()
+            self.assertRaises(StopAsyncIteration, c.send, None)
+
+        self.run_GC_test(task, asyncgen())
 
 
 class TestGeneratorWrapper(StacklessTestCase):


### PR DESCRIPTION
Silently ignore attempts to close a running generator, coroutine or asynchronous
generator. This avoids spurious error messages, if such an object is deallocated
as part of a paused, restorable tasklet.