### PR TITLE
Stackless issue #196: pickling of coroutine_wrapper objects

### DIFF
--- a/Stackless/changelog.txt
+++ b/Stackless/changelog.txt
@@ -9,6 +9,9 @@ What's New in Stackless 3.X.X?
 
 *Release date: 20XX-XX-XX*
 
+- https://github.com/stackless-dev/stackless/issues/195
+  Stackless can now pickle coroutine_wrapper objects.
+
 - https://github.com/stackless-dev/stackless/issues/190
   Silently ignore attempts to close a running generator, coroutine or
   asynchronous generator. This avoids spurious error messages, if such an

--- a/Stackless/changelog.txt
+++ b/Stackless/changelog.txt
@@ -9,7 +9,7 @@ What's New in Stackless 3.X.X?
 
 *Release date: 20XX-XX-XX*
 
-- https://github.com/stackless-dev/stackless/issues/195
+- https://github.com/stackless-dev/stackless/issues/196
   Stackless can now pickle coroutine_wrapper objects.
 
 - https://github.com/stackless-dev/stackless/issues/190

--- a/Stackless/core/stackless_impl.h
+++ b/Stackless/core/stackless_impl.h
@@ -741,6 +741,9 @@ int slp_resurrect_and_kill(PyObject *self,
                            void(*killer)(PyObject *));
 
 /* stackless pickling support */
+PyObject * slp_coro_wrapper_reduce(PyObject *o, PyTypeObject * wrapper_type);
+PyObject * slp_coro_wrapper_new(PyCoroObject *gen);
+PyObject * slp_coro_wrapper_setstate(PyObject *self, PyObject *args);
 int slp_async_gen_init_hooks(PyAsyncGenObject *o);
 PyObject * slp_async_gen_asend_reduce(PyObject *o, PyTypeObject * wrapper_type);
 PyObject * slp_async_gen_asend_new(PyAsyncGenObject *gen);

--- a/Tools/c-globals/ignored-globals.txt
+++ b/Tools/c-globals/ignored-globals.txt
@@ -500,6 +500,7 @@ Py_UnwindToken
 # justification: constant singleton
 gen_exhausted_frame
 gen_exhausted_asyncgen
+gen_exhausted_coro
 
 # justification: constant
 _new_methoddef


### PR DESCRIPTION
Stackless can now pickle coroutine_wrapper objects.
