### PR TITLE
Stackless issue #197: stackless call method "contextvars.Context.run"

### DIFF
--- a/Stackless/changelog.txt
+++ b/Stackless/changelog.txt
@@ -9,6 +9,10 @@ What's New in Stackless 3.X.X?
 
 *Release date: 20XX-XX-XX*
 
+- https://github.com/stackless-dev/stackless/issues/197
+  Enable stackless calls of method "contextvars.Context.run", if soft-switching
+  is enabled.
+
 - https://github.com/stackless-dev/stackless/issues/190
   Silently ignore attempts to close a running generator, coroutine or
   asynchronous generator. This avoids spurious error messages, if such an


### PR DESCRIPTION
Enable stackless calls of method "contextvars.Context.run", if
soft-switching is enabled.
