### PR TITLE
Stackless issue #201: enable stackless calls of "wrapper_descriptor"

### DIFF
--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -746,7 +746,7 @@ PyTypeObject PyWrapperDescr_Type = {
     0,                                          /* tp_descr_set */
 };
 
-/* STACKLESS_DECLARE_METHOD(&PyWrapperDescr_Type, tp_call) */
+STACKLESS_DECLARE_METHOD(&PyWrapperDescr_Type, tp_call)
 
 static PyDescrObject *
 descr_new(PyTypeObject *descrtype, PyTypeObject *type, const char *name)

--- a/Stackless/changelog.txt
+++ b/Stackless/changelog.txt
@@ -9,6 +9,11 @@ What's New in Stackless 3.X.X?
 
 *Release date: 20XX-XX-XX*
 
+- https://github.com/stackless-dev/stackless/issues/201
+  Enable stackless calls of "wrapper_descriptor" objects, if soft-switching is
+  enabled. The code has been in Stackless forever, but was disabled for some
+  unknown reason.
+
 - https://github.com/stackless-dev/stackless/issues/200
   Fix a bug in the C-API functions PyTasklet_Run_nr() and
   PyTasklet_Switch_nr(). Under exotic conditions the functions could

--- a/Stackless/core/stackless_methods.h
+++ b/Stackless/core/stackless_methods.h
@@ -19,6 +19,7 @@ static _stackless_method _stackless_methtable[] = {
     /* from descrobject.c */
     {&PyMethodDescr_Type,        MFLAG_OFS(tp_call)},
     {&PyClassMethodDescr_Type,    MFLAG_OFS(tp_call)},
+    {&PyWrapperDescr_Type,        MFLAG_OFS(tp_call)},
     {&_PyMethodWrapper_Type,    MFLAG_OFS(tp_call)},
     /* from funcobject.c */
     {&PyFunction_Type,            MFLAG_OFS(tp_call)},


### PR DESCRIPTION
objects, if soft-switching is enabled. The code has been in Stackless
forever, but was disabled for some unknown reason.

@ctismer Christian, do you remember, why this code was disabled?
