### PR TITLE
[2.7] Protect climb_stack_and_eval_frame from trivialization

### DIFF
--- a/Stackless/changelog.txt
+++ b/Stackless/changelog.txt
@@ -10,6 +10,11 @@ What's New in Stackless 2.7.XX?
 
 *Release date: XXXX-XX-XX*
 
+- https://github.com/stackless-dev/stackless/issues/227
+  Protect climb_stack_and_eval_frame from trivialization.
+  gcc-4.8.5 (and possibly other versions between 4.7 and 5.4) trivializes a
+  side-effect-only alloca. Patch by Milo Mirate.
+
 - https://github.com/stackless-dev/stackless/issues/220
   Improve the error handling in case of failed stack transfers / hard tasklet
   switches. Call Py_FatalError, if a clean recovery is impossible.

--- a/Stackless/core/stacklesseval.c
+++ b/Stackless/core/stacklesseval.c
@@ -267,6 +267,8 @@ make_initial_stub(void)
     return result;
 }
 
+/* a write only variable used to prevent overly optimisation */
+intptr_t *global_goobledigoobs;
 static PyObject *
 climb_stack_and_eval_frame(PyFrameObject *f)
 {
@@ -286,6 +288,10 @@ climb_stack_and_eval_frame(PyFrameObject *f)
         goobledigoobs = alloca(needed * sizeof(intptr_t));
         if (goobledigoobs == NULL)
             return NULL;
+        /* hinder the compiler to optimise away 
+           goobledigoobs and the alloca call. 
+           This happens with gcc 4.7.x and -O2 */
+        global_goobledigoobs = goobledigoobs;
     }
     return slp_eval_frame(f);
 }


### PR DESCRIPTION
gcc-4.8.5 (and possibly other versions between 4.7 and 5.4) trivializes both instances of the side-effect-only `alloca` trick: not only climb_stack_and_transfer, but also climb_stack_and_eval_frame.

Thus the same global-write trick must be used both there and here.

(This is of course entirely inapplicable to 3.x and master, due to #163.)