### PR TITLE
Stackless issue #281: Refactor tasklet profiling and tracing

### DIFF
--- a/Include/cpython/slp_structs.h
+++ b/Include/cpython/slp_structs.h
@@ -101,16 +101,6 @@ typedef struct _tasklet_flags {
     unsigned int pending_irq: SLP_TASKLET_FLAGS_BITS_pending_irq;
 } PyTaskletFlagStruc;
 
-/* a partial copy of PyThreadState. Used to preserve 
-   the state of a hard switched tasklet */
-typedef struct _tasklet_tstate {
-    int tracing;
-    Py_tracefunc c_profilefunc;
-    Py_tracefunc c_tracefunc;
-    PyObject *c_profileobj;
-    PyObject *c_traceobj;
-} PyTaskletTStateStruc;
-
 typedef struct _tasklet {
     PyObject_HEAD
     struct _tasklet *next;
@@ -133,9 +123,20 @@ typedef struct _tasklet {
     int recursion_depth;
     PyObject *def_globals;
     PyObject *tsk_weakreflist;
-    /* If the tasklet is current: NULL. (The context of a current tasklet is always in ts->tasklet.)
+    /* If the tasklet is current: NULL. (The context of a current tasklet is
+     *  always in ts->context.)
      * If the tasklet is not current: the context for the tasklet */
     PyObject *context;
+
+    /* If the tasklet is current: NULL. (The profile and tracing state of a
+     *  current tasklet is stored in the thread state.)
+     * If the tasklet is not current: the profile and tracing state for the tasklet.
+     */
+    Py_tracefunc profilefunc;
+    Py_tracefunc tracefunc;
+    PyObject *profileobj;
+    PyObject *traceobj;
+    int tracing;
 } PyTaskletObject;
 
 

--- a/Include/internal/pycore_stackless.h
+++ b/Include/internal/pycore_stackless.h
@@ -380,8 +380,6 @@ PyAPI_FUNC(PyObject *) PyEval_EvalFrameEx_slp(struct _frame *, int, PyObject *);
 /* eval_frame with stack overflow, triggered there with a macro */
 PyObject * slp_eval_frame_newstack(struct _frame *f, int throwflag, PyObject *retval);
 
-/* other eval_frame functions from module/scheduling.c */
-PyObject * slp_restore_tracing(PyCFrameObject *cf, int exc, PyObject *retval);
 /* other eval_frame functions from Objects/typeobject.c */
 PyObject * slp_tp_init_callback(PyCFrameObject *cf, int exc, PyObject *retval);
 /* functions related to pickling */
@@ -754,7 +752,6 @@ int slp_prepare_slots(PyTypeObject*);
 Py_tracefunc slp_get_sys_profile_func(void);
 Py_tracefunc slp_get_sys_trace_func(void);
 int slp_encode_ctrace_functions(Py_tracefunc c_tracefunc, Py_tracefunc c_profilefunc);
-PyTaskletTStateStruc * slp_get_saved_tstate(PyTaskletObject *task);
 
 /*
  * Channel related prototypes

--- a/Lib/stackless.py
+++ b/Lib/stackless.py
@@ -92,7 +92,7 @@ def _tasklet_get_unpicklable_state(tasklet):
 
         flags = pickle_flags(PICKLEFLAGS_PICKLE_CONTEXT, PICKLEFLAGS_PICKLE_CONTEXT)
         try:
-            return {'context': tasklet.__reduce__()[2][8]}
+            return {'context': tasklet.__reduce__()[2][12]}
         finally:
             pickle_flags(flags, PICKLEFLAGS_PICKLE_CONTEXT)
 

--- a/Stackless/changelog.txt
+++ b/Stackless/changelog.txt
@@ -9,6 +9,11 @@ What's New in Stackless 3.X.X?
 
 *Release date: 20XX-XX-XX*
 
+- https://github.com/stackless-dev/stackless/issues/281
+  Per tasklet profiling and tracing state information is now stored in the
+  tasklet itself. This increases the size of tasklet objects a bit, but saves a
+  lot of code.
+
 - https://github.com/stackless-dev/stackless/issues/270
   Stackless now uses an unmodified PyFrameObject structure. Stackless now
   stores more state information in the field f->f_executing than C-Python.

--- a/Stackless/pickling/prickelpit.c
+++ b/Stackless/pickling/prickelpit.c
@@ -828,7 +828,6 @@ static int init_functype(PyObject * mod)
 #define frametuplefmt "O)(OibOiOOiiOO"
 
 SLP_DEF_INVALID_EXEC(slp_channel_seq_callback)
-SLP_DEF_INVALID_EXEC(slp_restore_tracing)
 SLP_DEF_INVALID_EXEC(slp_tp_init_callback)
 
 static PyTypeObject wrap_PyFrame_Type;
@@ -1164,8 +1163,6 @@ static int init_frametype(PyObject * mod)
 {
     return slp_register_execute(&PyCFrame_Type, "channel_seq_callback",
                              slp_channel_seq_callback, SLP_REF_INVALID_EXEC(slp_channel_seq_callback))
-        || slp_register_execute(&PyCFrame_Type, "slp_restore_tracing",
-                             slp_restore_tracing, SLP_REF_INVALID_EXEC(slp_restore_tracing))
         || slp_register_execute(&PyCFrame_Type, "slp_tp_init_callback",
                              slp_tp_init_callback, SLP_REF_INVALID_EXEC(slp_tp_init_callback))
         || init_type(&wrap_PyFrame_Type, initchain, mod);

--- a/Stackless/unittests/test_exception.py
+++ b/Stackless/unittests/test_exception.py
@@ -27,8 +27,8 @@ class TestExcStatePickling(StacklessPickleTestCase):
         self.assertEqual(len(state), 3)
         state = state[2]
         self.assertIsInstance(state, tuple)
-        self.assertEqual(len(state), 8)
-        self.assertTupleEqual(state[-4:], (None, None, None, None))
+        self.assertEqual(len(state), 12)
+        self.assertTupleEqual(state[4:8], (None, None, None, None))
 
     def test_tasklet_pickle_with_exc(self):
         self.skipUnlessSoftswitching()

--- a/Stackless/unittests/test_tracing.py
+++ b/Stackless/unittests/test_tracing.py
@@ -126,6 +126,18 @@ class TestTracingProperties(StacklessTestCase):
         self.assertIsNone(tasklet.profile_function)
         self.assertGreater(self.tracecount, 0)
 
+    def testSetTraceOnDeadTasklet(self):
+        t = stackless.tasklet()
+        self.assertIsNone(t.trace_function)
+        t.trace_function = self.nullTraceFunc
+        self.assertIs(t.trace_function.__func__, self.nullTraceFunc.__func__)
+
+    def testSetProfileOnDeadTasklet(self):
+        t = stackless.tasklet()
+        self.assertIsNone(t.trace_function)
+        t.profile_function = self.nullTraceFunc
+        self.assertIs(t.profile_function.__func__, self.nullTraceFunc.__func__)
+
     def testSetTraceOnTasklet1(self):
         # Change trace state of a non-current tasklet
         # create tasklet, set trace, clear trace, run

--- a/Stackless/unittests/test_tracing.py
+++ b/Stackless/unittests/test_tracing.py
@@ -126,18 +126,6 @@ class TestTracingProperties(StacklessTestCase):
         self.assertIsNone(tasklet.profile_function)
         self.assertGreater(self.tracecount, 0)
 
-    def testSetTraceOnDeadTasklet(self):
-        t = stackless.tasklet()
-        self.assertIsNone(t.trace_function)
-        self.assertRaisesRegex(RuntimeError, "tasklet is not alive",
-                                setattr, t, "trace_function", self.nullTraceFunc)
-
-    def testSetProfileOnDeadTasklet(self):
-        t = stackless.tasklet()
-        self.assertIsNone(t.trace_function)
-        self.assertRaisesRegex(RuntimeError, "tasklet is not alive",
-                                setattr, t, "profile_function", self.nullTraceFunc)
-
     def testSetTraceOnTasklet1(self):
         # Change trace state of a non-current tasklet
         # create tasklet, set trace, clear trace, run

--- a/Stackless/unittests/test_tstate.py
+++ b/Stackless/unittests/test_tstate.py
@@ -332,16 +332,19 @@ class TestTracingState(StacklessTestCase):
             return
 
         # test if the tracing cframe is present / not present
-        reduce_frame = get_reduce_frame()
-        self.assertListEqual(reduced_tasklet1[2][3], [reduce_frame(frame)])
-        self.assertEqual(len(reduced_tasklet2[2][3]), 2)
-        self.assertIs(reduced_tasklet2[2][3][0], reduce_frame(frame))
-        self.assertIsInstance(reduced_tasklet2[2][3][1], stackless.cframe)
+        self.assertIsInstance(reduced_tasklet1[2][8], int)
+        self.assertEqual(reduced_tasklet1[2][8], 0)
+        self.assertIsInstance(reduced_tasklet1[2][9], int)
+        self.assertEqual(reduced_tasklet1[2][9], 0)
+        self.assertIsNone(reduced_tasklet1[2][10])
+        self.assertIsNone(reduced_tasklet1[2][11])
 
-        cf = reduced_tasklet2[2][3][1]
-        reduced_cframe = cf.__reduce__()
-        self.assertEqual(reduced_cframe[2][1], 'slp_restore_tracing')
-        self.assertIs(reduced_cframe[2][2][1].__func__, self.Callback.__func__)
+        self.assertIsInstance(reduced_tasklet2[2][8], int)
+        self.assertEqual(reduced_tasklet2[2][8], 0)
+        self.assertIsInstance(reduced_tasklet2[2][9], int)
+        self.assertEqual(reduced_tasklet2[2][9], 1)
+        self.assertIsNone(reduced_tasklet2[2][10])
+        self.assertIs(reduced_tasklet2[2][11].__func__, self.Callback.__func__)
 
 if __name__ == '__main__':
     if not sys.argv[1:]:


### PR DESCRIPTION
Per tasklet profiling and tracing state information is now stored in the
tasklet itself. This increases the size of tasklet objects a bit, but
saves a lot of code.