### PR TITLE
Stackless issue #287: Remove STACKLESS_SPY and clean up platform code

### DIFF
--- a/Include/internal/pycore_stackless.h
+++ b/Include/internal/pycore_stackless.h
@@ -23,14 +23,6 @@ extern "C" {
 #endif
 #include "pycore_slp_prickelpit.h"
 
-#undef STACKLESS_SPY
-/*
- * if a platform wants to support self-inspection via _peek,
- * it must provide a function or macro SLP_CANNOT_READ_MEM(adr, len)
- * which allows to spy at memory without causing exceptions.
- * This would usually be done in place with the assembly macros.
- */
-
 #ifndef SLP_END_OF_OLD_CYTHON_HACK_VERSION
 /*
  * If PY_VERSION_HEX < SLP_END_OF_OLD_CYTHON_VERSION_HEX support for

--- a/Include/stackless.h
+++ b/Include/stackless.h
@@ -41,12 +41,16 @@ extern "C" {
     /* an option to switch it off */
 #elif defined(MS_WIN32) && !defined(MS_WIN64) && defined(_M_IX86)
     /* MS Visual Studio on X86 */
+#   define SLP_USE_NATIVE_BITFIELD_LAYOUT 1
 #elif defined(_WIN64) && defined(_M_X64)
     /* microsoft on 64 bit x64 thingies */
+#   define SLP_USE_NATIVE_BITFIELD_LAYOUT 1
 #elif defined(__GNUC__) && defined(__i386__)
     /* gcc on X86 */
+#   define SLP_USE_NATIVE_BITFIELD_LAYOUT 1
 #elif defined(__GNUC__) && defined(__amd64__)
     /* gcc on AMD64 */
+#   define SLP_USE_NATIVE_BITFIELD_LAYOUT 1
 #elif defined(__GNUC__) && defined(__PPC__) && defined(__linux__)
     /* gcc on PowerPC */
 #elif defined(__GNUC__) && defined(__ppc__) && defined(__APPLE__)

--- a/Stackless/changelog.txt
+++ b/Stackless/changelog.txt
@@ -9,6 +9,9 @@ What's New in Stackless 3.X.X?
 
 *Release date: 20XX-XX-XX*
 
+- https://github.com/stackless-dev/stackless/issues/287
+  The experimental STACKLESS_SPY feature has been removed.
+
 - https://github.com/stackless-dev/stackless/issues/283
   Platform dependent source code is now completely in "Stackless/platf". The
   API header files do not depend on the platform any longer and the header

--- a/Stackless/platf/switch_amd64_unix.h
+++ b/Stackless/platf/switch_amd64_unix.h
@@ -29,8 +29,6 @@
  *      Ported from i386.
  */
 
-#define SLP_USE_NATIVE_BITFIELD_LAYOUT 1
-
 #define SLP_STACK_REFPLUS 1
 
 #ifdef SLP_EVAL
@@ -140,13 +138,3 @@ slp_switch(void)
 
 #undef REGS_CLOBBERED
 #endif
-/*
- * further self-processing support
- */
-
-/* 
- * if you want to add self-inspection tools, place them
- * here. See the x86_msvc for the necessary defines.
- * These features are highly experimental und not
- * essential yet.
- */

--- a/Stackless/platf/switch_mips_unix.h
+++ b/Stackless/platf/switch_mips_unix.h
@@ -45,13 +45,3 @@ slp_switch(void)
 #undef REGS_TO_SAVE
 #endif
 
-/*
- * further self-processing support
- */
-
-/*
- * if you want to add self-inspection tools, place them
- * here. See the x86_msvc for the necessary defines.
- * These features are highly experimental und not
- * essential yet.
- */

--- a/Stackless/platf/switch_ppc_macosx.h
+++ b/Stackless/platf/switch_ppc_macosx.h
@@ -74,13 +74,3 @@ slp_switch(void)
 #undef REGS_TO_SAVE
 #endif
 
-/*
- * further self-processing support
- */
-
-/*
- * if you want to add self-inspection tools, place them
- * here. See the x86_msvc for the necessary defines.
- * These features are highly experimental und not
- * essential yet.
- */

--- a/Stackless/platf/switch_ppc_unix.h
+++ b/Stackless/platf/switch_ppc_unix.h
@@ -62,13 +62,3 @@ slp_switch(void)
 #undef REGS_TO_SAVE
 #endif
 
-/*
- * further self-processing support
- */
-
-/* 
- * if you want to add self-inspection tools, place them
- * here. See the x86_msvc for the necessary defines.
- * These features are highly experimental und not
- * essential yet.
- */

--- a/Stackless/platf/switch_s390_unix.h
+++ b/Stackless/platf/switch_s390_unix.h
@@ -42,13 +42,3 @@ slp_switch(void)
 #undef REGS_TO_SAVE
 #endif
 
-/*
- * further self-processing support
- */
-
-/*
- * if you want to add self-inspection tools, place them
- * here. See the x86_msvc for the necessary defines.
- * These features are highly experimental und not
- * essential yet.
- */

--- a/Stackless/platf/switch_sparc_sun_gcc.h
+++ b/Stackless/platf/switch_sparc_sun_gcc.h
@@ -73,13 +73,3 @@ slp_switch(void)
 
 #endif
 
-/*
- * further self-processing support
- */
-
-/*
- * if you want to add self-inspection tools, place them
- * here. See the x86_msvc for the necessary defines.
- * These features are highly experimental und not
- * essential yet.
- */

--- a/Stackless/platf/switch_x64_msvc.h
+++ b/Stackless/platf/switch_x64_msvc.h
@@ -22,8 +22,6 @@
  *      Initial final version after lots of iterations for i386.
  */
 
-#define SLP_USE_NATIVE_BITFIELD_LAYOUT 1
-
 #define SLP_STACK_REFPLUS 1
 #define SLP_STACK_MAGIC 0
 
@@ -34,21 +32,3 @@
 /* This always uses the external masm assembly file. */
 #endif
 
-/*
- * further self-processing support
- */
-
-/* we have IsBadReadPtr available, so we can peek at objects */
-#define STACKLESS_SPY
-
-#ifdef IMPLEMENT_STACKLESSMODULE
-#define SLP_CANNOT_READ_MEM(p, bytes) IsBadReadPtr(p, bytes)
-
-static int SLP_IS_ON_STACK(void*p)
-{
-    int stackref;
-    intptr_t stackbase = ((intptr_t)&stackref) & 0xfffff000;
-    return (intptr_t)p >= stackbase && (intptr_t)p < stackbase + 0x00100000;
-}
-
-#endif

--- a/Stackless/platf/switch_x86_msvc.h
+++ b/Stackless/platf/switch_x86_msvc.h
@@ -22,8 +22,6 @@
  *      Initial final version after lots of iterations for i386.
  */
 
-#define SLP_USE_NATIVE_BITFIELD_LAYOUT 1
-
 #define SLP_STACK_REFPLUS 1
 
 /* switching related stuff */
@@ -57,21 +55,3 @@ slp_switch(void)
 
 #endif
 
-/*
- * further self-processing support
- */
-
-/* we have IsBadReadPtr available, so we can peek at objects */
-#define STACKLESS_SPY
-
-#ifdef IMPLEMENT_STACKLESSMODULE
-#define SLP_CANNOT_READ_MEM(p, bytes) IsBadReadPtr(p, bytes)
-
-static int SLP_IS_ON_STACK(void*p)
-{
-    int stackref;
-    int stackbase = ((int)&stackref) & 0xfffff000;
-    return (int)p >= stackbase && (int)p < stackbase + 0x00100000;
-}
-
-#endif

--- a/Stackless/platf/switch_x86_unix.h
+++ b/Stackless/platf/switch_x86_unix.h
@@ -21,8 +21,6 @@
  *      Ported from i386.
  */
 
-#define SLP_USE_NATIVE_BITFIELD_LAYOUT 1
-
 #define SLP_STACK_REFPLUS 1
 
 #ifdef SLP_EVAL
@@ -102,13 +100,3 @@ slp_switch(void)
 #undef REGS_CLOBBERED
 #endif
 
-/*
- * further self-processing support
- */
-
-/*
- * if you want to add self-inspection tools, place them
- * here. See the x86_msvc for the necessary defines.
- * These features are highly experimental und not
- * essential yet.
- */


### PR DESCRIPTION
Remove the STACKLESS_SPY feature. It is dangerous and not worth the effort.
Move the definition of SLP_USE_NATIVE_BITFIELD_LAYOUT from platform header files to Include/stackless.h.
Clean up platform header files.
