### PR TITLE
Stackless issue #294: convert Stackless type definitions to new syntax

### DIFF
--- a/Stackless/core/cframeobject.c
+++ b/Stackless/core/cframeobject.c
@@ -321,44 +321,18 @@ static PyMemberDef cframe_memberlist[] = {
 
 PyTypeObject PyCFrame_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
-    "_stackless.cframe",
-    sizeof(PyCFrameObject),
-    0,
-    (destructor)cframe_dealloc,        /* tp_dealloc */
-    0,                                 /* tp_print */
-    0,                                 /* tp_getattr */
-    0,                                 /* tp_setattr */
-    0,                                 /* tp_compare */
-    0,                                 /* tp_repr */
-    0,                                 /* tp_as_number */
-    0,                                 /* tp_as_sequence */
-    0,                                 /* tp_as_mapping */
-    0,                                 /* tp_hash */
-    0,                                 /* tp_call */
-    0,                                 /* tp_str */
-    PyObject_GenericGetAttr,           /* tp_getattro */
-    PyObject_GenericSetAttr,           /* tp_setattro */
-    0,                                 /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC, /* tp_flags */
-    0,                                 /* tp_doc */
-    (traverseproc)cframe_traverse,        /* tp_traverse */
-    (inquiry) cframe_clear,            /* tp_clear */
-    0,                                 /* tp_richcompare */
-    0,                                 /* tp_weaklistoffset */
-    0,                                 /* tp_iter */
-    0,                                 /* tp_iternext */
-    cframe_methods,                    /* tp_methods */
-    cframe_memberlist,                 /* tp_members */
-    0,                                 /* tp_getset */
-    0,                                 /* tp_base */
-    0,                                 /* tp_dict */
-    0,                                 /* tp_descr_get */
-    0,                                 /* tp_descr_set */
-    0,                                 /* tp_dictoffset */
-    0,                                 /* tp_init */
-    0,                                 /* tp_alloc */
-    cframe_new,                        /* tp_new */
-    PyObject_GC_Del,                   /* tp_free */
+    .tp_name = "_stackless.cframe",
+    .tp_basicsize = sizeof(PyCFrameObject),
+    .tp_dealloc = (destructor)cframe_dealloc,
+    .tp_getattro = PyObject_GenericGetAttr,
+    .tp_setattro = PyObject_GenericSetAttr,
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
+    .tp_traverse = (traverseproc)cframe_traverse,
+    .tp_clear = (inquiry) cframe_clear,
+    .tp_methods = cframe_methods,
+    .tp_members = cframe_memberlist,
+    .tp_new = cframe_new,
+    .tp_free = PyObject_GC_Del
 };
 
 int slp_init_cframetype(void)
@@ -425,35 +399,12 @@ extension function written in C in a pickle.\n\
 
 PyTypeObject PyStacklessFunctionDeclaration_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
-    "_stackless.FunctionDeclaration",             /*tp_name*/
-    sizeof(PyStacklessFunctionDeclarationObject),          /*tp_basicsize*/
-    0,                          /*tp_itemsize*/
-    /* methods */
-    0,                                 /* tp_dealloc */
-    0,                                 /* tp_print */
-    0,                                 /* tp_getattr */
-    0,                                 /* tp_setattr */
-    0,                                 /* tp_compare */
-    0,                                 /* tp_repr */
-    0,                                 /* tp_as_number */
-    0,                                 /* tp_as_sequence */
-    0,                                 /* tp_as_mapping */
-    0,                                 /* tp_hash */
-    0,                                 /* tp_call */
-    0,                                 /* tp_str */
-    0,                                 /* tp_getattro */
-    0,                                 /* tp_setattro */
-    0,                                 /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,                /* tp_flags */
-    PyStacklessFunctionDeclaration_Type__doc__, /* tp_doc */
-    0,                                 /* tp_traverse */
-    0,                                 /* tp_clear */
-    0,                                 /* tp_richcompare */
-    0,                                 /* tp_weaklistoffset */
-    0,                                 /* tp_iter */
-    0,                                 /* tp_iternext */
-    function_declaration_methods,    /* tp_methods */
-    function_declaration_memberlist, /* tp_members */
+    .tp_name = "_stackless.FunctionDeclaration",
+    .tp_basicsize = sizeof(PyStacklessFunctionDeclarationObject),
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_doc = PyStacklessFunctionDeclaration_Type__doc__,
+    .tp_methods = function_declaration_methods,
+    .tp_members = function_declaration_memberlist
 };
 
 static

--- a/Stackless/core/stacklesseval.c
+++ b/Stackless/core/stacklesseval.c
@@ -186,34 +186,16 @@ cstack_str(PyObject *o)
 
 PyTypeObject PyCStack_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
-    "_stackless.cstack",
-    sizeof(PyCStackObject),
-    sizeof(PyObject *),
-    (destructor)cstack_dealloc,         /* tp_dealloc */
-    0,                                  /* tp_print */
-    0,                                  /* tp_getattr */
-    0,                                  /* tp_setattr */
-    0,                                  /* tp_compare */
-    0,                                  /* tp_repr */
-    0,                                  /* tp_as_number */
-    0,                                  /* tp_as_sequence */
-    0,                                  /* tp_as_mapping */
-    0,                                  /* tp_hash */
-    0,                                  /* tp_call */
-    (reprfunc)cstack_str,               /* tp_str */
-    PyObject_GenericGetAttr,            /* tp_getattro */
-    PyObject_GenericSetAttr,            /* tp_setattro */
-    0,                                  /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,                 /* tp_flags */
-    cstack_doc,                         /* tp_doc */
-    0,                                  /* tp_traverse */
-    0,                                  /* tp_clear */
-    0,                                  /* tp_richcompare */
-    0,                                  /* tp_weaklistoffset */
-    0,                                  /* tp_iter */
-    0,                                  /* tp_iternext */
-    0,                                  /* tp_methods */
-    cstack_members,                     /* tp_members */
+    .tp_name = "_stackless.cstack",
+    .tp_basicsize = sizeof(PyCStackObject),
+    .tp_itemsize = sizeof(PyObject *),
+    .tp_dealloc = (destructor)cstack_dealloc,
+    .tp_str = (reprfunc)cstack_str,
+    .tp_getattro = PyObject_GenericGetAttr,
+    .tp_setattro = PyObject_GenericSetAttr,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_doc = cstack_doc,
+    .tp_members = cstack_members
 };
 
 
@@ -970,19 +952,9 @@ static void unwind_dealloc(PyObject *op) {
 
 static PyTypeObject PyUnwindToken_Type = {
     PyVarObject_HEAD_INIT(&PyUnwindToken_Type, 0)
-    "UnwindToken",
-    0,
-    0,
-    (destructor)unwind_dealloc, /*tp_dealloc*/ /*should never be called*/
-    0,                  /*tp_print*/
-    0,                  /*tp_getattr*/
-    0,                  /*tp_setattr*/
-    0,                  /*tp_compare*/
-    (reprfunc)unwind_repr, /*tp_repr*/
-    0,                  /*tp_as_number*/
-    0,                  /*tp_as_sequence*/
-    0,                  /*tp_as_mapping*/
-    0,                  /*tp_hash */
+    .tp_name = "UnwindToken",
+    .tp_dealloc = (destructor)unwind_dealloc, /*should never be called*/
+    .tp_repr = (reprfunc)unwind_repr
 };
 
 static PyUnwindObject unwind_token = {

--- a/Stackless/module/_teststackless.c
+++ b/Stackless/module/_teststackless.c
@@ -269,46 +269,11 @@ static PyTypeObject SoftSwitchableDemo_Type = {
     /* The ob_type field must be initialized in the module init function
      * to be portable to Windows without using C++. */
     PyVarObject_HEAD_INIT(NULL, 0)
-    "_teststackless.SoftSwitchableDemo",             /*tp_name*/
-    sizeof(SoftSwitchableDemoObject),          /*tp_basicsize*/
-    0,                          /*tp_itemsize*/
-    /* methods */
-    0,                          /*tp_dealloc*/
-    0,                          /*tp_print*/
-    0,                          /*tp_getattr*/
-    0,                          /*tp_setattr*/
-    0,                          /*tp_reserved*/
-    0,                          /*tp_repr*/
-    0,                          /*tp_as_number*/
-    0,                          /*tp_as_sequence*/
-    0,                          /*tp_as_mapping*/
-    0,                          /*tp_hash*/
-    0,                          /*tp_call*/
-    0,                          /*tp_str*/
-    0,                          /*tp_getattro*/
-    0,                          /*tp_setattro*/
-    0,                          /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,         /*tp_flags*/
-    0,                          /*tp_doc*/
-    0,                          /*tp_traverse*/
-    0,                          /*tp_clear*/
-    0,                          /*tp_richcompare*/
-    0,                          /*tp_weaklistoffset*/
-    0,                          /*tp_iter*/
-    0,                          /*tp_iternext*/
-    SoftSwitchableDemo_methods,                /*tp_methods*/
-    0,                          /*tp_members*/
-    0,                          /*tp_getset*/
-    0,                          /*tp_base*/
-    0,                          /*tp_dict*/
-    0,                          /*tp_descr_get*/
-    0,                          /*tp_descr_set*/
-    0,                          /*tp_dictoffset*/
-    0,                          /*tp_init*/
-    0,                          /*tp_alloc*/
-    PyType_GenericNew,          /*tp_new*/
-    0,                          /*tp_free*/
-    0,                          /*tp_is_gc*/
+    .tp_name = "_teststackless.SoftSwitchableDemo",
+    .tp_basicsize = sizeof(SoftSwitchableDemoObject),
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    .tp_methods = SoftSwitchableDemo_methods,
+    .tp_new = PyType_GenericNew,
 };
 /* --------------------------------------------------------------------- */
 

--- a/Stackless/module/channelobject.c
+++ b/Stackless/module/channelobject.c
@@ -1218,47 +1218,26 @@ static PyMappingMethods channel_as_mapping = {
 
 PyTypeObject PyChannel_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
-    "_stackless.channel",
-    sizeof(PyChannelObject),
-    0,
-    (destructor)channel_dealloc,                /* tp_dealloc */
-    0,                                          /* tp_print */
-    0,                                          /* tp_getattr */
-    0,                                          /* tp_setattr */
-    0,                                          /* tp_compare */
-    0,                                          /* tp_repr */
-    0,                                          /* tp_as_number */
-    0,                                          /* tp_as_sequence */
-    SLP_TP_AS_MAPPING(channel_as_mapping),      /* tp_as_mapping */
-    0,                                          /* tp_hash */
-    0,                                          /* tp_call */
-    0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
-    PyObject_GenericSetAttr,                    /* tp_setattro */
-    0,                                          /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
+    .tp_name = "_stackless.channel",
+    .tp_basicsize = sizeof(PyChannelObject),
+    .tp_dealloc = (destructor)channel_dealloc,
+    .tp_as_mapping = SLP_TP_AS_MAPPING(channel_as_mapping),
+    .tp_getattro = PyObject_GenericGetAttr,
+    .tp_setattro = PyObject_GenericSetAttr,
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE |
-        Py_TPFLAGS_HAVE_STACKLESS_EXTENSION,    /* tp_flags */
-    channel__doc__,                             /* tp_doc */
-    (traverseproc)channel_traverse,             /* tp_traverse */
-    (inquiry) channel_clear,                    /* tp_clear */
-    0,                                          /* tp_richcompare */
-    offsetof(PyChannelObject, chan_weakreflist),
-                                            /* tp_weaklistoffset */
-    (getiterfunc)channel_getiter,               /* tp_iter */
-    (iternextfunc)channel_iternext,             /* tp_iternext */
-    channel_methods,                            /* tp_methods */
-    channel_members,                            /* tp_members */
-    channel_getsetlist,                         /* tp_getset */
-    0,                                          /* tp_base */
-    0,                                          /* tp_dict */
-    0,                                          /* tp_descr_get */
-    0,                                          /* tp_descr_set */
-    0,                                          /* tp_dictoffset */
-    0,                                          /* tp_init */
-    0,                                          /* tp_alloc */
-    channel_new,                                /* tp_new */
-    PyObject_GC_Del,                            /* tp_free */
+        Py_TPFLAGS_HAVE_STACKLESS_EXTENSION,
+    .tp_doc = channel__doc__,
+    .tp_traverse = (traverseproc)channel_traverse,
+    .tp_clear = (inquiry) channel_clear,
+    .tp_weaklistoffset = offsetof(PyChannelObject, chan_weakreflist),
+    .tp_iter = (getiterfunc)channel_getiter,
+    .tp_iternext = (iternextfunc)channel_iternext,
+    .tp_methods = channel_methods,
+    .tp_members = channel_members,
+    .tp_getset = channel_getsetlist,
+    .tp_new = channel_new,
+    .tp_free = PyObject_GC_Del,
 };
 
 #endif

--- a/Stackless/module/scheduling.c
+++ b/Stackless/module/scheduling.c
@@ -276,44 +276,19 @@ t.run()  # let the bomb explode");
 
 PyTypeObject PyBomb_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
-    "_stackless.bomb",
-    sizeof(PyBombObject),
-    0,
-    (destructor)bomb_dealloc,                   /* tp_dealloc */
-    0,                                          /* tp_print */
-    0,                                          /* tp_getattr */
-    0,                                          /* tp_setattr */
-    0,                                          /* tp_compare */
-    0,                                          /* tp_repr */
-    0,                                          /* tp_as_number */
-    0,                                          /* tp_as_sequence */
-    0,                                          /* tp_as_mapping */
-    0,                                          /* tp_hash */
-    0,                                          /* tp_call */
-    0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
-    PyObject_GenericSetAttr,                    /* tp_setattro */
-    0,                                          /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC, /* tp_flags */
-    bomb__doc__,                                /* tp_doc */
-    (traverseproc)bomb_traverse,                /* tp_traverse */
-    (inquiry) bomb_clear,                       /* tp_clear */
-    0,                                          /* tp_richcompare */
-    0,                                          /* tp_weaklistoffset */
-    0,                                          /* tp_iter */
-    0,                                          /* tp_iternext */
-    bomb_methods,                               /* tp_methods */
-    bomb_members,                               /* tp_members */
-    0,                                          /* tp_getset */
-    0,                                          /* tp_base */
-    0,                                          /* tp_dict */
-    0,                                          /* tp_descr_get */
-    0,                                          /* tp_descr_set */
-    0,                                          /* tp_dictoffset */
-    0,                                          /* tp_init */
-    0,                                          /* tp_alloc */
-    bomb_new,                                   /* tp_new */
-    PyObject_GC_Del,                            /* tp_free */
+    .tp_name = "_stackless.bomb",
+    .tp_basicsize = sizeof(PyBombObject),
+    .tp_dealloc = (destructor)bomb_dealloc,
+    .tp_getattro = PyObject_GenericGetAttr,
+    .tp_setattro = PyObject_GenericSetAttr,
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
+    .tp_doc = bomb__doc__,
+    .tp_traverse = (traverseproc)bomb_traverse,
+    .tp_clear = (inquiry) bomb_clear,
+    .tp_methods = bomb_methods,
+    .tp_members = bomb_members,
+    .tp_new = bomb_new,
+    .tp_free = PyObject_GC_Del,
 };
 
 int

--- a/Stackless/module/stacklessmodule.c
+++ b/Stackless/module/stacklessmodule.c
@@ -75,43 +75,14 @@ current tasklet to true for the duration.\n");
 
 PyTypeObject PyAtomic_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "_stackless.atomic",
-    sizeof(PyAtomicObject),
-    0,
-    0,                                          /* tp_dealloc */
-    0,                                          /* tp_print */
-    0,                                          /* tp_getattr */
-    0,                                          /* tp_setattr */
-    0,                                          /* tp_compare */
-    0,                                          /* tp_repr */
-    0,                                          /* tp_as_number */
-    0,                                          /* tp_as_sequence */
-    0,                                          /* tp_as_mapping */
-    0,                                          /* tp_hash */
-    0,                                          /* tp_call */
-    0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
-    PyObject_GenericSetAttr,                    /* tp_setattro */
-    0,                                          /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,                         /* tp_flags */
-    PyAtomic_Type__doc__,                       /* tp_doc */
-    0,                                          /* tp_traverse */
-    0,                                          /* tp_clear */
-    0,                                          /* tp_richcompare */
-    0,                                          /* tp_weaklistoffset */
-    0,                                          /* tp_iter */
-    0,                                          /* tp_iternext */
-    atomic_methods,                             /* tp_methods */
-    0,                                          /* tp_members */
-    0,                                          /* tp_getset */
-    0,                                          /* tp_base */
-    0,                                          /* tp_dict */
-    0,                                          /* tp_descr_get */
-    0,                                          /* tp_descr_set */
-    0,                                          /* tp_dictoffset */
-    0,                                          /* tp_init */
-    0,                                          /* tp_alloc */
-    PyType_GenericNew,                          /* tp_new */
+    .tp_name = "_stackless.atomic",
+    .tp_basicsize = sizeof(PyAtomicObject),
+    .tp_getattro = PyObject_GenericGetAttr,
+    .tp_setattro = PyObject_GenericSetAttr,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_doc = PyAtomic_Type__doc__,
+    .tp_methods = atomic_methods,
+    .tp_new = PyType_GenericNew
 };
 
 /******************************************************
@@ -1178,26 +1149,11 @@ static PyObject *get_test_nostacklesscallobj(void)
 {
     static PyTypeObject test_nostacklesscallType = {
             PyVarObject_HEAD_INIT(NULL, 0)
-            "_stackless.test_nostacklesscall_type",   /*tp_name*/
-            sizeof(test_nostacklesscallObject), /*tp_basicsize*/
-            0,                         /*tp_itemsize*/
-            0,                         /*tp_dealloc*/
-            0,                         /*tp_print*/
-            0,                         /*tp_getattr*/
-            0,                         /*tp_setattr*/
-            0,                         /*tp_reserved*/
-            0,                         /*tp_repr*/
-            0,                         /*tp_as_number*/
-            0,                         /*tp_as_sequence*/
-            0,                         /*tp_as_mapping*/
-            0,                         /*tp_hash */
-            test_nostacklesscall_call, /*tp_call*/
-            0,                         /*tp_str*/
-            0,                         /*tp_getattro*/
-            0,                         /*tp_setattro*/
-            0,                         /*tp_as_buffer*/
-            Py_TPFLAGS_DEFAULT & ~(Py_TPFLAGS_HAVE_STACKLESS_EXTENSION | Py_TPFLAGS_HAVE_STACKLESS_CALL) ,        /*tp_flags*/
-            test_nostacklesscalltype__doc__, /* tp_doc */
+            .tp_name = "_stackless.test_nostacklesscall_type",
+            .tp_basicsize = sizeof(test_nostacklesscallObject),
+            .tp_call = test_nostacklesscall_call,
+            .tp_flags = Py_TPFLAGS_DEFAULT & ~(Py_TPFLAGS_HAVE_STACKLESS_EXTENSION | Py_TPFLAGS_HAVE_STACKLESS_CALL),
+            .tp_doc = test_nostacklesscalltype__doc__
     };
 
     test_nostacklesscallType.tp_new = PyType_GenericNew;

--- a/Stackless/module/taskletobject.c
+++ b/Stackless/module/taskletobject.c
@@ -2498,54 +2498,25 @@ module.\n\
 
 PyTypeObject PyTasklet_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
-    "_stackless.tasklet",
-    sizeof(PyTaskletObject),
-    0,
-    (destructor)tasklet_dealloc,        /* tp_dealloc */
-    0,                                  /* tp_print */
-    0,                                  /* tp_getattr */
-    0,                                  /* tp_setattr */
-    0,                                  /* tp_compare */
-    0,                                  /* tp_repr */
-    0,                                  /* tp_as_number */
-    0,                                  /* tp_as_sequence */
-    0,                                  /* tp_as_mapping */
-    0,                                  /* tp_hash */
-    tasklet_setup,                      /* tp_call */
-    0,                                  /* tp_str */
-    PyObject_GenericGetAttr,            /* tp_getattro */
-    PyObject_GenericSetAttr,            /* tp_setattro */
-    0,                                  /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
+    .tp_name = "_stackless.tasklet",
+    .tp_basicsize = sizeof(PyTaskletObject),
+    .tp_dealloc = (destructor)tasklet_dealloc,
+    .tp_call = tasklet_setup,
+    .tp_getattro = PyObject_GenericGetAttr,
+    .tp_setattro = PyObject_GenericSetAttr,
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE |
-        Py_TPFLAGS_HAVE_FINALIZE,       /* tp_flags */
-    tasklet__doc__,                     /* tp_doc */
-    (traverseproc)tasklet_traverse,     /* tp_traverse */
-    (inquiry) tasklet_clear,            /* tp_clear */
-    0,                                  /* tp_richcompare */
-    offsetof(PyTaskletObject, tsk_weakreflist), /* tp_weaklistoffset */
-    0,                                  /* tp_iter */
-    0,                                  /* tp_iternext */
-    tasklet_methods,                    /* tp_methods */
-    tasklet_members,                    /* tp_members */
-    tasklet_getsetlist,                 /* tp_getset */
-    0,                                  /* tp_base */
-    0,                                  /* tp_dict */
-    0,                                  /* tp_descr_get */
-    0,                                  /* tp_descr_set */
-    0,                                  /* tp_dictoffset */
-    tasklet_init,                       /* tp_init */
-    0,                                  /* tp_alloc */
-    tasklet_new,                        /* tp_new */
-    PyObject_GC_Del,                    /* tp_free */
-    0,                                  /* tp_is_gc */
-    0,                                  /* tp_bases */
-    0,                                  /* tp_mro */
-    0,                                  /* tp_cache */
-    0,                                  /* tp_subclasses */
-    0,                                  /* tp_weaklist */
-    0,                                  /* tp_del */
-    0,                                  /* tp_version_tag */
-    tasklet_finalize,                   /* tp_finalize */
+        Py_TPFLAGS_HAVE_FINALIZE,
+    .tp_doc = tasklet__doc__,
+    .tp_traverse = (traverseproc)tasklet_traverse,
+    .tp_clear = (inquiry) tasklet_clear,
+    .tp_weaklistoffset = offsetof(PyTaskletObject, tsk_weakreflist),
+    .tp_methods = tasklet_methods,
+    .tp_members = tasklet_members,
+    .tp_getset = tasklet_getsetlist,
+    .tp_init = tasklet_init,
+    .tp_new = tasklet_new,
+    .tp_free = PyObject_GC_Del,
+    .tp_finalize = tasklet_finalize
 };
 #endif

--- a/Stackless/pickling/prickelpit.c
+++ b/Stackless/pickling/prickelpit.c
@@ -149,44 +149,16 @@ static PyMethodDef prefix##_methods[] = { \
  \
 static struct _typeobject wrap_##type = { \
     PyVarObject_HEAD_INIT(&PyType_Type, 0) \
-    "_stackless._wrap." name, \
-    0, \
-    0, \
-    (destructor)_wrap_dealloc,              /* tp_dealloc */ \
-    0,                                          /* tp_print */ \
-    0,                                          /* tp_getattr */ \
-    0,                                          /* tp_setattr */ \
-    0,                                          /* tp_compare */ \
-    0,                                          /* tp_repr */ \
-    0,                                          /* tp_as_number */ \
-    0,                                          /* tp_as_sequence */ \
-    0,                                          /* tp_as_mapping */ \
-    0,                                          /* tp_hash */ \
-    0,                                          /* tp_call */ \
-    0,                                          /* tp_str */ \
-    PyObject_GenericGetAttr,                    /* tp_getattro */ \
-    PyObject_GenericSetAttr,                    /* tp_setattro */ \
-    0,                                          /* tp_as_buffer */ \
-    0,                                          /* tp_flags */ \
-    0,                                          /* tp_doc */ \
-    (traverseproc) _wrap_traverse,              /* tp_traverse */ \
-    (inquiry) _wrap_clear,                  /* tp_clear */ \
-    0,                                          /* tp_richcompare */ \
-    0,                                          /* tp_weaklistoffset */ \
-    0,                                          /* tp_iter */ \
-    0,                                          /* tp_iternext */ \
-    prefix##_methods,                           /* tp_methods */ \
-    0,                                          /* tp_members */ \
-    0,                                          /* tp_getset */ \
-    &type,                                      /* tp_base */ \
-    0,                                          /* tp_dict */ \
-    0,                                          /* tp_descr_get */ \
-    0,                                          /* tp_descr_set */ \
-    0,                                          /* tp_dictoffset */ \
-    slp_generic_init,                           /* tp_init */ \
-    0,                                          /* tp_alloc */ \
-    newfunc,                                    /* tp_new */ \
-    0,                                          /* tp_free */ \
+    .tp_name = "_stackless._wrap." name, \
+    .tp_dealloc = (destructor)_wrap_dealloc, \
+    .tp_getattro = PyObject_GenericGetAttr, \
+    .tp_setattro = PyObject_GenericSetAttr, \
+    .tp_traverse = (traverseproc) _wrap_traverse, \
+    .tp_clear = (inquiry) _wrap_clear, \
+    .tp_methods = prefix##_methods, \
+    .tp_base = &type, \
+    .tp_init = slp_generic_init, \
+    .tp_new = newfunc, \
 };
 
 


### PR DESCRIPTION
Convert initializers for static type objects to use C99 designator
syntax. This way the code is more robust against changes of
PyTypeObject.
