### PR TITLE
Use 'B' instead of 'b' to parse/build char value.

### DIFF
--- a/Stackless/pickling/prickelpit.c
+++ b/Stackless/pickling/prickelpit.c
@@ -957,7 +957,7 @@ static int init_functype(PyObject * mod)
 
  ******************************************************/
 
-#define frametuplefmt "O)(OibOiOOiiOO"
+#define frametuplefmt "O)(OiBOiOOiiOO"
 
 SLP_DEF_INVALID_EXEC(slp_channel_seq_callback)
 SLP_DEF_INVALID_EXEC(slp_tp_init_callback)
@@ -1049,7 +1049,7 @@ err_exit:
 }
 
 #define frametuplenewfmt "O!:frame.__new__"
-#define frametuplesetstatefmt "O!ibO!iO!OiiO!O:frame.__setstate__"
+#define frametuplesetstatefmt "O!iBO!iO!OiiO!O:frame.__setstate__"
 
 static PyObject *
 frame_new(PyTypeObject *type, PyObject *args, PyObject *kwds)


### PR DESCRIPTION
Issue:

* `pickle.load` raises `OverflowError` if loaded content includes `PyFrameObject`, whose `f_executing` is set to `SLP_FRAME_EXECUTING_INVALID`.

Solution:

* Use 'B' instead of 'b' to parse/build char value when frame object is pickled.

How to reproduce this issue:

* The following code causes `OverflowError` unexpectedly.  
  ```python
   import pickle
   import stackless
   import sys


   try:
       raise RuntimeError()
   except:
       traceback_object = sys.exc_info()[2]
   a = pickle.dumps(traceback_object)
   b = pickle.loads(a)
   c = pickle.dumps(b)
   d = pickle.loads(c)
   # => This raises "OverflowError: unsigned byte integer is less than minimum".
  ```

Details:

* `f_executing` in `PyFrameObject` is declared as `char`, which might be signed depending on implementation.  
  Therefore, 'B' should be specified when `Py_BuildValue` and 'PyArg_ParseTuple` is called.
* If 'b' is specified instead of 'B' and `f_executing` is set to `SLP_FRAME_EXECUTING_INVALID`, `PyArg_ParseTuple` in `frame_setstate` in `Stackless\pickling\prickelpit.c` raises OverflowError.  
  This is raised in `convertsimple` in `Python\getargs.c` because `SLP_FRAME_EXECUTING_INVALID` is less than `0`.